### PR TITLE
CRS encoding and permutation

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -271,9 +271,8 @@ struct Covering {
 /**
  * Bounding box of geometries in the representation of min/max value pair of
  * coordinates from each axis. Values of Z and M are omitted for 2D geometries.
- * Filter pushdown on geometries are only safe for planar spatial predicate
- * but it is recommended that the writer always generates bounding box statistics,
- * regardless of whether the geometries are planar or spherical.
+ * Filter pushdown on geometries using this is only safe for planar spatial
+ * filters.
  */
 struct BoundingBox {
   1: required double xmin;

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -250,7 +250,7 @@ enum Edges {
 /**
  * A custom binary-encoded polygon or multi-polygon to represent a covering of
  * geometries. For example, it may be a bounding box or an envelope of geometries
- * when a bounding box cannot be built (e.g., a geometry has spherical edges, or if
+ * when a bounding box cannot be built (e.g. a geometry has spherical edges, or if
  * an edge of geographic coordinates crosses the antimeridian). In addition, it can
  * also be used to provide vendor-agnostic coverings like S2 or H3 grids.
  */
@@ -291,7 +291,12 @@ struct GeometryStatistics {
   /** A bounding box of geometries */
   1: optional BoundingBox bbox;
 
-  /** A list of coverings of geometries */
+  /**
+   * A list of coverings of geometries.
+   * Note that It is allowed to have more than one covering of the same kind and
+   * implementation is free to use any of them. It is recommended to have at most
+   * one covering for each kind.
+   */
   2: optional list<Covering> coverings;
 
   /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -238,9 +238,16 @@ struct SizeStatistics {
 }
 
 /**
- * Interpretation for edges of GEOMETRY logical type, i.e. whether the edge
- * between points represent a straight cartesian line or the shortest line on
- * the sphere. It applies to all non-point geometry objects.
+ * Interpretation for edges of elements of a GEOMETRY logical type. In other
+ * words, whether a point between two vertices should be interpolated in
+ * its XY dimensions as if it were a Cartesian line connecting the two
+ * vertices (planar) or the shortest spherical arc between the longitude
+ * and latitude represented by the two vertices (spherical). This value
+ * applies to all non-point geometry objects and is independent of the
+ * coordinate reference system.
+ *
+ * Because most systems currently assume planar edges and do not support
+ * spherical edges, planar should be used as the default value.
  */
 enum Edges {
   PLANAR = 0;

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -258,8 +258,9 @@ enum Edges {
  * A custom binary-encoded polygon or multi-polygon to represent a covering of
  * geometries. For example, it may be a bounding box or an envelope of geometries
  * when a bounding box cannot be built (e.g. a geometry has spherical edges, or if
- * an edge of geographic coordinates crosses the antimeridian). In addition, it can
- * also be used to provide vendor-agnostic coverings like S2 or H3 grids.
+ * an edge of geographic coordinates crosses the antimeridian). It may be
+ * extended in future versions to provide vendor-agnostic coverings like
+ * vectors of cells on a discrete global grid (e.g., S2 or H3 cells).
  */
 struct Covering {
   /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -270,6 +270,9 @@ struct Covering {
 /**
  * Bounding box of geometries in the representation of min/max value pair of
  * coordinates from each axis. Values of Z and M are omitted for 2D geometries.
+ * Filter pushdown on geometries are only safe for planar spatial predicate
+ * but it is recommended that the writer always generates bounding box statistics,
+ * regardless of whether the geometries are planar or spherical.
  */
 struct BoundingBox {
   1: required double xmin;

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -503,9 +503,9 @@ struct GeometryType {
   2: required Edges edges;
   /**
    * Coordinate Reference System, i.e. mapping of how coordinates refer to
-   * precise locations on earth.
-   *
-   * For example, OGC:CRS84 encoded in PROJJSON is set as below:
+   * precise locations on earth. Writers are not required to set this field.
+   * Once crs is set, crs_encoding field below MUST be set together.
+   * For example, "OGC:CRS84" can be set in the form of PROJJSON as below:
    * {
    *     "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
    *     "type": "GeographicCRS",
@@ -544,8 +544,7 @@ struct GeometryType {
    */
   3: optional string crs;
   /**
-   * Encoding used in the above crs field. If MUST be set if crs is set.
-   *
+   * Encoding used in the above crs field. It MUST be set if crs field is set.
    * Currently the only allowed value is "PROJJSON".
    */
   4: optional string crs_encoding;

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -279,43 +279,26 @@ enum GeometryEncoding {
  * Because most systems currently assume planar edges and do not support
  * spherical edges, planar should be used as the default value.
  */
-enum EdgeInterpolation {
+enum Edges {
   PLANAR = 0;
   SPHERICAL = 1;
 }
 
 /**
- * A custom binary-encoded polygon or multi-polygon to represent a covering of
- * geometries. For example, it may be a bounding box or an envelope of geometries
- * when a bounding box cannot be built (e.g. a geometry has spherical edges, or if
- * an edge of geographic coordinates crosses the antimeridian). It may be
- * extended in future versions to provide vendor-agnostic coverings like
- * vectors of cells on a discrete global grid (e.g., S2 or H3 cells).
- */
-struct Covering {
-  /**
-   * A type of covering. Currently accepted values: "WKB".
-   */
-  1: required string kind;
-  /**
-   * A payload specific to kind. Below are the supported values:
-   * - WKB: well-known binary of a POLYGON or MULTI-POLYGON that completely
-   *   covers the contents. This will be interpreted according to the same CRS
-   *   and edges defined by the logical type.
-   */
-  2: required binary value;
-}
-
-/**
  * Bounding box of geometries in the representation of min/max value pair of
- * coordinates from each axis. Values of Z and M are omitted for 2D geometries.
- * Filter pushdown on geometries using this is only safe for planar spatial
- * filters.
+ * coordinates from each axis when Edges is planar. Values of Z and M are omitted
+ * for 2D geometries. When Edges is spherical, the bounding box is in the form of
+ * [westmost, eastmost, southmost, northmost], with necessary min/max values for
+ * Z and M if needed.
  */
 struct BoundingBox {
+  /** Westmost value if edges = spherical **/
   1: required double xmin;
+  /** Eastmost value if edges = spherical **/
   2: required double xmax;
+  /** Southmost value if edges = spherical **/
   3: required double ymin;
+  /** Northmost value if edges = spherical **/
   4: required double ymax;
   5: optional double zmin;
   6: optional double zmax;
@@ -327,14 +310,6 @@ struct BoundingBox {
 struct GeometryStatistics {
   /** A bounding box of geometries */
   1: optional BoundingBox bbox;
-
-  /**
-   * A list of coverings of geometries.
-   * Note that It is allowed to have more than one covering of the same kind and
-   * implementation is free to use any of them. It is recommended to have at most
-   * one covering for each kind.
-   */
-  2: optional list<Covering> coverings;
 
   /**
    * The geometry types of all geometries, or an empty array if they are not
@@ -363,7 +338,7 @@ struct GeometryStatistics {
    * [1] https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary
    * [2] https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L159
    */
-  3: optional list<i32> geometry_types;
+  2: optional list<i32> geometry_types;
 }
 
 /**
@@ -520,65 +495,24 @@ struct GeometryType {
    * line or the shortest line on the sphere.
    * Please refer to the definition of Edges for more detail.
    */
-  2: required EdgeInterpolation edges;
+  2: required Edges edges;
   /**
-   * Coordinate Reference System, i.e. mapping of how coordinates refer to
-   * precise locations on earth. Writers are not required to set this field.
-   * Once crs is set, crs_encoding field below MUST be set together.
-   * For example, "OGC:CRS84" can be set in the form of PROJJSON as below:
-   * {
-   *     "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-   *     "type": "GeographicCRS",
-   *     "name": "WGS 84 longitude-latitude",
-   *     "datum": {
-   *         "type": "GeodeticReferenceFrame",
-   *         "name": "World Geodetic System 1984",
-   *         "ellipsoid": {
-   *             "name": "WGS 84",
-   *             "semi_major_axis": 6378137,
-   *             "inverse_flattening": 298.257223563
-   *         }
-   *     },
-   *     "coordinate_system": {
-   *         "subtype": "ellipsoidal",
-   *         "axis": [
-   *         {
-   *             "name": "Geodetic longitude",
-   *             "abbreviation": "Lon",
-   *             "direction": "east",
-   *             "unit": "degree"
-   *         },
-   *         {
-   *             "name": "Geodetic latitude",
-   *             "abbreviation": "Lat",
-   *             "direction": "north",
-   *             "unit": "degree"
-   *         }
-   *         ]
-   *     },
-   *     "id": {
-   *         "authority": "OGC",
-   *         "code": "CRS84"
-   *     }
-   * }
+   * CRS (coordinate reference system) is a mapping of how coordinates refer to
+   * precise locations on earth. A crs is specified by a string, which is a Parquet
+   * file metadata field whose value is the crs representation. An additional field
+   * with the suffix '.type' describes the encoding of this CRS representation.
+   *
+   * For example, if a geometry column (e.g., 'geom1') uses the CRS 'OGC:CRS84', the
+   * writer may create 2 file metadata fields: 'geom1_crs' and 'geom1_crs.type', and
+   * set the 'crs' field to 'geom1_crs'. The 'geom1_crs' field will contain the
+   * PROJJSON representation of OGC:CRS84
+   * (https://github.com/opengeospatial/geoparquet/blob/main/format-specs/geoparquet.md#ogccrs84-details),
+   * and the 'geom1_crs.type' field will contain the string 'PROJJSON'.
+   *
+   * Multiple geometry columns can refer to the same CRS metadata field
+   * (e.g., 'geom1_crs') if they share the same CRS.
    */
   3: optional string crs;
-  /**
-   * Encoding used in the above crs field. It MUST be set if crs field is set.
-   * Currently the only allowed value is "PROJJSON".
-   */
-  4: optional string crs_encoding;
-  /**
-   * Additional informative metadata as a list of key-value pair of UTF-8 string.
-   *
-   * It is not strictly required by the low-level Parquet implementation for
-   * features like statistics or filter pushdown. Using a list of key-value pair
-   * provides maximum flexibility for adding future informative metadata.
-   *
-   * GeoParquet could store its column metadata in this field:
-   * https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L46
-   */
-  5: optional list<KeyValue> key_value_metadata;
 }
 
 /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -248,7 +248,7 @@ enum Edges {
 }
 
 /**
- * A custom WKB-encoded polygon or multi-polygon to represent a covering of
+ * A custom binary-encoded polygon or multi-polygon to represent a covering of
  * geometries. For example, it may be a bounding box or an envelope of geometries
  * when a bounding box cannot be built (e.g., a geometry has spherical edges, or if
  * an edge of geographic coordinates crosses the antimeridian). In addition, it can
@@ -259,10 +259,11 @@ struct Covering {
    * A type of covering. Currently accepted values: "WKB".
    */
   1: required string kind;
-  /** A payload specific to kind:
-   * - WKB: well-known binary of a POLYGON that completely covers the contents.
-   *   This will be interpreted according to the same CRS and edges defined by
-   *   the logical type.
+  /**
+   * A payload specific to kind:
+   * - WKB: well-known binary of a POLYGON or MULTI-POLYGON that completely
+   *   covers the contents. This will be interpreted according to the same CRS
+   *   and edges defined by the logical type.
    */
   2: required binary value;
 }
@@ -318,7 +319,7 @@ struct GeometryStatistics {
    *
    * Please refer to links below for more detail:
    * [1] https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary
-   * [2] https://github.com/opengeospatial/geoparquet/blob/v1.0.0/format-specs/geoparquet.md?plain=1#L91
+   * [2] https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L159
    */
   3: optional list<i32> geometry_types;
 }
@@ -476,6 +477,11 @@ enum GeometryEncoding {
    *
    * This encoding enables GeometryStatistics to be set in the column chunk
    * and page index.
+   *
+   * Please note that we follow the same rule of WKB and coordinate axis order
+   * of GeoParquet, see detail below:
+   * [1] https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L92
+   * [2] https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L155
    */
   WKB = 0;
 
@@ -507,9 +513,10 @@ struct GeometryType {
   4: optional string crs_encoding;
   /**
    * Additional informative metadata.
-   * It can be used by GeoParquet to offload some of the column metadata.
+   * GeoParquet could offload its column metadata in a JSON-encoded UTF-8 string:
+   * https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L46
    */
-  5: optional binary metadata;
+  5: optional string metadata;
 }
 
 /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -270,8 +270,11 @@ struct Statistics {
     * may set min_value="B", max_value="C". Such more compact values must still be
     * valid values within the column's logical type.
     *
-    * Values are encoded using PLAIN encoding, except that variable-length byte
-    * arrays do not include a length prefix.
+    * Values are encoded using PLAIN encoding, except that:
+    * 1) variable-length byte arrays do not include a length prefix.
+    * 2) geometry logical type with BoundingBoxOrder uses max_value/min_value pair
+    *    to store the bounding box for the column. Please refer to the definition
+    *    of BoundingBoxOrder for detail.
     */
    5: optional binary max_value;
    6: optional binary min_value;
@@ -374,6 +377,69 @@ struct BsonType {
 }
 
 /**
+ * A geometry can be any of the following subtypes.
+ * The list of geospatial subtypes is taken from the OGC (Open Geospatial Consortium)
+ * SFA (Simple Feature Access) Part 1- Common Architecture.
+ */
+enum GeometrySubType {
+  POINT = 0;
+  LINESTRING = 1;
+  POLYGON = 2;
+  MULTIPOINT = 3;
+  MULTILINESTRING = 4;
+  MULTIPOLYGON = 5;
+  GEOMETRY_COLLECTION = 6;
+}
+
+/**
+ * Interpretation for edges, i.e. whether the edge between points
+ * represent a straight cartesian line or the shortest line on the sphere
+ */
+enum Edges {
+  PLANAR = 0;
+  // SPHERICAL = 1; // not supported yet
+}
+
+/**
+ * Well-Known Binary. This is a well-known and popular binary representation regulated
+ * by the Open Geospatial Consortium (OGC). 
+ */
+struct WKB {}
+/**
+ * Encoding for geospatial data.
+ */
+union GeospatialEncoding {
+  1: WKB WKB
+}
+
+/**
+ * Geometry logical type annotation
+ *
+ * Allowed for physical types: BINARY (added in 2.11.0)
+ */
+struct GeometryType {
+  /**
+   * The subtype of the geometry.
+   * If set, all values in the column must be of the same subtype.
+   * If not set, the column may contain values of any subtype.
+   */
+  1: optional GeometrySubType subtype;
+  /**
+   * The dimension of the geometry.
+   * For now only 2D geometry is supported and the value must be 2 if set.
+   */
+  2: optional byte dimension;
+  /**
+   * Coordinate Reference System, i.e. mapping of how coordinates refer to
+   * precise locations on earth.
+   * For now only OGC:CRS84 is supported.
+   */
+  3: optional string crs;
+  4: required Edges edges;
+  5: required GeospatialEncoding encoding;
+}
+
+/**
  * LogicalType annotations to replace ConvertedType.
  *
  * To maintain compatibility, implementations using LogicalType for a
@@ -403,6 +469,7 @@ union LogicalType {
   13: BsonType BSON           // use ConvertedType BSON
   14: UUIDType UUID           // no compatible ConvertedType
   15: Float16Type FLOAT16     // no compatible ConvertedType
+  16: GeometryType GEOMETRY   // no compatible ConvertedType
 }
 
 /**
@@ -916,6 +983,8 @@ struct RowGroup {
 
 /** Empty struct to signal the order defined by the physical or logical type */
 struct TypeDefinedOrder {}
+/** Empty struct to signal the order of GEOMETRY logical type */
+struct BoundingBoxOrder {}
 
 /**
  * Union to specify the order used for the min_value and max_value fields for a
@@ -925,6 +994,8 @@ struct TypeDefinedOrder {}
  * Possible values are:
  * * TypeDefinedOrder - the column uses the order defined by its logical or
  *                      physical type (if there is no logical type).
+ * * BoundingBoxOrder - the column uses the order to build bounding box
+ *                      (if the logical type is GEOMETRY).
  *
  * If the reader does not support the value of this union, min and max stats
  * for this column should be ignored.
@@ -954,6 +1025,7 @@ union ColumnOrder {
    *   ENUM - unsigned byte-wise comparison
    *   LIST - undefined
    *   MAP - undefined
+   *   GEOMETRY - undefined, as geometry objects cannot be compared directly
    *
    * In the absence of logical types, the sort order is determined by the physical type:
    *   BOOLEAN - false, true
@@ -982,6 +1054,23 @@ union ColumnOrder {
    *       `-0.0` should be written into the min statistics field.
    */
   1: TypeDefinedOrder TYPE_ORDER;
+
+  /**
+   * The order only applies to GEOMETRY logical type.
+   *
+   * Please note that geometry objects cannot be compared directly. This order aims to
+   * provide an approach to build a bounding box for geometry objects in the same page
+   * or column chunk.
+   *
+   * In this order, all 2D geometries are regarded as a collection of coordinate (x, y).
+   * For example, POINT has one coordinate, LINESTRING has two coordinates, and POLYGON
+   * might have three or more coordinates. A bounding box is the combination of x_min,
+   * x_max, y_min, and y_max of all coordinates from all geometry values. For simplexty,
+   * min_value field in the Statistics/ColumnIndex is encoded as the concatenation of
+   * PLAIN-encoded DOUBLE-typed x_min and y_min values. Similarly, max_value field is
+   * encoded as the concatenation of PLAIN-encoded DOUBLE-typed x_max and y_max values.
+   */
+  2: BoundingBoxOrder BBOX_ORDER;
 }
 
 struct PageLocation {
@@ -1052,6 +1141,9 @@ struct ColumnIndex {
    * Such more compact values must still be valid values within the column's
    * logical type. Readers must make sure that list entries are populated before
    * using them by inspecting null_pages.
+   *
+   * For GEOMETRY logical type, these values are the bounding box of the column.
+   * Please refer to the definition of BoundingBoxOrder for detail.
    */
   2: required list<binary> min_values
   3: required list<binary> max_values
@@ -1061,6 +1153,8 @@ struct ColumnIndex {
    * which direction. This allows readers to perform binary searches in both
    * lists. Readers cannot assume that max_values[i] <= min_values[i+1], even
    * if the lists are ordered.
+   *
+   * For GEOMETRY type, UNORDERED is used at all times.
    */
   4: required BoundaryOrder boundary_order
 

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -504,10 +504,48 @@ struct GeometryType {
   /**
    * Coordinate Reference System, i.e. mapping of how coordinates refer to
    * precise locations on earth.
+   *
+   * For example, OGC:CRS84 encoded in PROJJSON is set as below:
+   * {
+   *     "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
+   *     "type": "GeographicCRS",
+   *     "name": "WGS 84 longitude-latitude",
+   *     "datum": {
+   *         "type": "GeodeticReferenceFrame",
+   *         "name": "World Geodetic System 1984",
+   *         "ellipsoid": {
+   *             "name": "WGS 84",
+   *             "semi_major_axis": 6378137,
+   *             "inverse_flattening": 298.257223563
+   *         }
+   *     },
+   *     "coordinate_system": {
+   *         "subtype": "ellipsoidal",
+   *         "axis": [
+   *         {
+   *             "name": "Geodetic longitude",
+   *             "abbreviation": "Lon",
+   *             "direction": "east",
+   *             "unit": "degree"
+   *         },
+   *         {
+   *             "name": "Geodetic latitude",
+   *             "abbreviation": "Lat",
+   *             "direction": "north",
+   *             "unit": "degree"
+   *         }
+   *         ]
+   *     },
+   *     "id": {
+   *         "authority": "OGC",
+   *         "code": "CRS84"
+   *     }
+   * }
    */
   3: optional string crs;
   /**
-   * Encoding used in the above crs field.
+   * Encoding used in the above crs field. If MUST be set if crs is set.
+   *
    * Currently the only allowed value is "PROJJSON".
    */
   4: optional string crs_encoding;

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -249,16 +249,22 @@ enum Edges {
 
 /**
  * A custom WKB-encoded polygon or multi-polygon to represent a covering of
- * geometries. For example, it may be a bounding box, or an evelope of geometries
- * when a bounding box cannot be built (e.g. a geometry has spherical edges, or if
+ * geometries. For example, it may be a bounding box or an envelope of geometries
+ * when a bounding box cannot be built (e.g., a geometry has spherical edges, or if
  * an edge of geographic coordinates crosses the antimeridian). In addition, it can
  * also be used to provide vendor-agnostic coverings like S2 or H3 grids.
  */
 struct Covering {
-  /** Bytes of a WKB-encoded geometry */
-  1: required binary geometry;
-  /** Edges of the geometry, which is independent of edges from the logical type */
-  2: required Edges edges;
+  /**
+   * A type of covering. Currently accepted values: "WKB".
+   */
+  1: required string kind;
+  /** A payload specific to kind:
+   * - WKB: well-known binary of a POLYGON that completely covers the contents.
+   *   This will be interpreted according to the same CRS and edges defined by
+   *   the logical type.
+   */
+  2: required binary value;
 }
 
 /**
@@ -281,8 +287,8 @@ struct GeometryStatistics {
   /** A bounding box of geometries */
   1: optional BoundingBox bbox;
 
-  /** A covering polygon of geometries */
-  2: optional Covering covering;
+  /** A list of coverings of geometries */
+  2: optional list<Covering> coverings;
 
   /**
    * The geometry types of all geometries, or an empty array if they are not
@@ -488,14 +494,19 @@ struct GeometryType {
   2: required Edges edges;
   /**
    * Coordinate Reference System, i.e. mapping of how coordinates refer to
-   * precise locations on earth, e.g. OGC:CRS84
+   * precise locations on earth.
    */
   3: optional string crs;
+  /**
+   * Encoding used in the above crs field.
+   * Currently the only allowed value is "PROJJSON".
+   */
+  4: optional string crs_encoding;
   /**
    * Additional informative metadata.
    * It can be used by GeoParquet to offload some of the column metadata.
    */
-  4: optional binary metadata;
+  5: optional binary metadata;
 }
 
 /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -472,6 +472,8 @@ struct GeometryType {
    * It can be used by GeoParquet to offload some of the column metadata.
    */
   2: optional string metadata;
+  /** File-level statistics for geometries */
+  3: optional GeometryStatistics statistics;
 }
 
 /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -570,9 +570,13 @@ struct GeometryType {
   4: optional string crs_encoding;
   /**
    * Additional informative metadata as a list of key-value pair of UTF-8 string.
+   *
    * It is not strictly required by the low-level Parquet implementation for
    * features like statistics or filter pushdown. Using a list of key-value pair
    * provides maximum flexibility for adding future informative metadata.
+   *
+   * GeoParquet could store its column metadata in this field:
+   * https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L46
    */
   5: optional list<KeyValue> key_value_metadata;
 }

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -238,6 +238,38 @@ struct SizeStatistics {
 }
 
 /**
+ * Bounding box of geometries in the representation of min/max value pair of
+ * coordinates from each axis. Values of Z and M are omitted for 2D geometries.
+ */
+struct BoundingBox {
+  1: optional double x_min;
+  2: optional double x_max;
+  3: optional double y_min;
+  4: optional double y_max;
+  5: optional double z_min;
+  6: optional double z_max;
+  7: optional double m_min;
+  8: optional double m_max;
+}
+
+/** Statistics specific to GEOMETRY logical type */
+struct GeometryStatistics {
+  /** Bounding box of geometries */
+  1: optional BoundingBox bbox;
+  /** Covering of geometries as a list of Google S2 cell ids */
+  2: list<i64> s2_cell_ids;
+  /** Covering of geometries as a list of Uber H3 indices */
+  3: list<i64> h3_indices;
+  /**
+   * The geometry types of all geometries, or an empty array if they are not
+   * known. It follows the same rule of `geometry_types` column metadata of
+   * GeoParquet. Accepted geometry types are: "Point", "LineString", "Polygon",
+   * "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection".
+   */
+  4: list<string> geometry_types;
+}
+
+/**
  * Statistics per row group and per page
  * All fields are optional.
  */
@@ -270,11 +302,8 @@ struct Statistics {
     * may set min_value="B", max_value="C". Such more compact values must still be
     * valid values within the column's logical type.
     *
-    * Values are encoded using PLAIN encoding, except that:
-    * 1) variable-length byte arrays do not include a length prefix.
-    * 2) geometry logical type with BoundingBoxOrder uses max_value/min_value pair
-    *    to store the bounding box for the column. Please refer to the definition
-    *    of BoundingBoxOrder for detail.
+    * Values are encoded using PLAIN encoding, except that variable-length byte
+    * arrays do not include a length prefix.
     */
    5: optional binary max_value;
    6: optional binary min_value;
@@ -282,6 +311,9 @@ struct Statistics {
    7: optional bool is_max_value_exact;
    /** If true, min_value is the actual minimum value for a column */
    8: optional bool is_min_value_exact;
+
+   /** statistics specific to geometry logical type */
+   9: optional GeometryStatistics geometry_stats;
 }
 
 /** Empty structs to use as logical type annotations */
@@ -377,66 +409,69 @@ struct BsonType {
 }
 
 /**
- * A geometry can be any of the following subtypes.
- * The list of geospatial subtypes is taken from the OGC (Open Geospatial Consortium)
- * SFA (Simple Feature Access) Part 1- Common Architecture.
+ * Phyiscal type and encoding for the geometry type.
  */
-enum GeometrySubType {
-  POINT = 0;
-  LINESTRING = 1;
-  POLYGON = 2;
-  MULTIPOINT = 3;
-  MULTILINESTRING = 4;
-  MULTIPOLYGON = 5;
-  GEOMETRY_COLLECTION = 6;
+enum GeometryEncoding {
+  /**
+   * Allowed for phyiscal type: BYTE_ARRAY.
+   *
+   * Well-known binary (WKB) representations of geometries. It supports 2D or
+   * 3D geometries of the standard geometry types (Point, LineString, Polygon,
+   * MultiPoint, MultiLineString, MultiPolygon, and GeometryCollection). This
+   * is the preferred option for maximum portability.
+   *
+   * This encoding enables GeometryStatistics to be set in the column chunk
+   * and page index.
+   */
+  WKB = 0;
+
+  /**
+   * Encodings from POINT to MULTIPOLYGON below are specialized for single
+   * geometry type and inspired by GeoArrow (https://geoarrow.org/format.html)
+   * native encodings. It uses the separated (struct) representation of
+   * coordinates for single-geometry type encodings because this encoding
+   * results in useful column statistics when row groups and/or files contain
+   * related features.
+   *
+   * WARNING: GeometryStatistics cannot be enabled for these encodings because
+   * only leaf columns can have column statistics and page index.
+   *
+   * The actual coordinates of the geometries MUST be stored as native numbers,
+   * i.e. using the DOUBLE type in a (repeated) group of fields (exact
+   * repetition depending on the geometry type).
+   *
+   * For the POINT encoding, this results in a struct of two fields for x and y
+   * coordinates (in case of 2D geometries):
+   * optional group geometry {
+   *   required double x;
+   *   required double y;
+   * }
+   *
+   * For more detail, please refer to link below:
+   * https://github.com/opengeospatial/geoparquet/blob/main/format-specs/geoparquet.md#encoding
+   */
+  POINT = 1;
+  LINESTRING = 2;
+  POLYGON = 3;
+  MULTIPOINT = 4;
+  MULTILINESTRING = 5;
+  MULTIPOLYGON = 6;
 }
 
 /**
- * Interpretation for edges, i.e. whether the edge between points
- * represent a straight cartesian line or the shortest line on the sphere
- */
-enum Edges {
-  PLANAR = 0;
-  // SPHERICAL = 1; // not supported yet
-}
-
-/**
- * Well-Known Binary. This is a well-known and popular binary representation regulated
- * by the Open Geospatial Consortium (OGC). 
- */
-struct WKB {}
-/**
- * Encoding for geospatial data.
- */
-union GeospatialEncoding {
-  1: WKB WKB
-}
-
-/**
- * Geometry logical type annotation
- *
- * Allowed for physical types: BINARY (added in 2.11.0)
+ * Geometry logical type annotation (added in 2.11.0)
  */
 struct GeometryType {
   /**
-   * The subtype of the geometry.
-   * If set, all values in the column must be of the same subtype.
-   * If not set, the column may contain values of any subtype.
+   * Phyiscal type and encoding for the geometry type. Please refer to the
+   * definition of GeometryEncoding for more detail.
    */
-  1: optional GeometrySubType subtype;
+  1: required GeometryEncoding encoding;
   /**
-   * The dimension of the geometry.
-   * For now only 2D geometry is supported and the value must be 2 if set.
+   * Additional informative metadata.
+   * It can be used by GeoParquet to offload some of the column metadata.
    */
-  2: optional byte dimension;
-  /**
-   * Coordinate Reference System, i.e. mapping of how coordinates refer to
-   * precise locations on earth.
-   * For now only OGC:CRS84 is supported.
-   */
-  3: optional string crs;
-  4: required Edges edges;
-  5: required GeospatialEncoding encoding;
+  2: optional string metadata;
 }
 
 /**
@@ -983,8 +1018,6 @@ struct RowGroup {
 
 /** Empty struct to signal the order defined by the physical or logical type */
 struct TypeDefinedOrder {}
-/** Empty struct to signal the order of GEOMETRY logical type */
-struct BoundingBoxOrder {}
 
 /**
  * Union to specify the order used for the min_value and max_value fields for a
@@ -994,8 +1027,6 @@ struct BoundingBoxOrder {}
  * Possible values are:
  * * TypeDefinedOrder - the column uses the order defined by its logical or
  *                      physical type (if there is no logical type).
- * * BoundingBoxOrder - the column uses the order to build bounding box
- *                      (if the logical type is GEOMETRY).
  *
  * If the reader does not support the value of this union, min and max stats
  * for this column should be ignored.
@@ -1025,7 +1056,7 @@ union ColumnOrder {
    *   ENUM - unsigned byte-wise comparison
    *   LIST - undefined
    *   MAP - undefined
-   *   GEOMETRY - undefined, as geometry objects cannot be compared directly
+   *   GEOMETRY - undefined, use GeometryStatistics instead.
    *
    * In the absence of logical types, the sort order is determined by the physical type:
    *   BOOLEAN - false, true
@@ -1054,23 +1085,6 @@ union ColumnOrder {
    *       `-0.0` should be written into the min statistics field.
    */
   1: TypeDefinedOrder TYPE_ORDER;
-
-  /**
-   * The order only applies to GEOMETRY logical type.
-   *
-   * Please note that geometry objects cannot be compared directly. This order aims to
-   * provide an approach to build a bounding box for geometry objects in the same page
-   * or column chunk.
-   *
-   * In this order, all 2D geometries are regarded as a collection of coordinate (x, y).
-   * For example, POINT has one coordinate, LINESTRING has two coordinates, and POLYGON
-   * might have three or more coordinates. A bounding box is the combination of x_min,
-   * x_max, y_min, and y_max of all coordinates from all geometry values. For simplexty,
-   * min_value field in the Statistics/ColumnIndex is encoded as the concatenation of
-   * PLAIN-encoded DOUBLE-typed x_min and y_min values. Similarly, max_value field is
-   * encoded as the concatenation of PLAIN-encoded DOUBLE-typed x_max and y_max values.
-   */
-  2: BoundingBoxOrder BBOX_ORDER;
 }
 
 struct PageLocation {
@@ -1141,9 +1155,6 @@ struct ColumnIndex {
    * Such more compact values must still be valid values within the column's
    * logical type. Readers must make sure that list entries are populated before
    * using them by inspecting null_pages.
-   *
-   * For GEOMETRY logical type, these values are the bounding box of the column.
-   * Please refer to the definition of BoundingBoxOrder for detail.
    */
   2: required list<binary> min_values
   3: required list<binary> max_values
@@ -1153,8 +1164,6 @@ struct ColumnIndex {
    * which direction. This allows readers to perform binary searches in both
    * lists. Readers cannot assume that max_values[i] <= min_values[i+1], even
    * if the lists are ordered.
-   *
-   * For GEOMETRY type, UNORDERED is used at all times.
    */
   4: required BoundaryOrder boundary_order
 
@@ -1178,6 +1187,9 @@ struct ColumnIndex {
     * Same as repetition_level_histograms except for definitions levels.
     **/
    7: optional list<i64> definition_level_histograms;
+
+   /** A list containing statistics of GEOMETRY logical type for each page */
+   8: optional list<GeometryStatistics> geometry_stats;
 }
 
 struct AesGcmV1 {

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -286,22 +286,32 @@ struct GeometryStatistics {
 
   /**
    * The geometry types of all geometries, or an empty array if they are not
-   * known. It follows the same rule of `geometry_types` column metadata of
-   * GeoParquet. Accepted geometry types are: "Point", "LineString", "Polygon",
-   * "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection".
+   * known. This is borrowed from `geometry_types` column metadata of GeoParquet [1]
+   * except that values in the list are WKB (ISO variant) integer codes [2]. Table
+   * below shows the most common geometry types and their codes:
+   *
+   * | Type               | XY   | XYZ  | XYM  | XYZM |
+   * | :----------------- | :--- | :--- | :--- | :--: |
+   * | Point              | 0001 | 1001 | 2001 | 3001 |
+   * | LineString         | 0002 | 1002 | 2002 | 3002 |
+   * | Polygon            | 0003 | 1003 | 2003 | 3003 |
+   * | MultiPoint         | 0004 | 1004 | 2004 | 3004 |
+   * | MultiLineString    | 0005 | 1005 | 2005 | 3005 |
+   * | MultiPolygon       | 0006 | 1006 | 2006 | 3006 |
+   * | GeometryCollection | 0007 | 1007 | 2007 | 3007 |
    *
    * In addition, the following rules are used:
-   * - In case of 3D geometries, a `" Z"` suffix gets added (e.g. `["Point Z"]`).
    * - A list of multiple values indicates that multiple geometry types are
-   *   present (e.g. `["Polygon", "MultiPolygon"]`).
+   *   present (e.g. `[0003, 0006]`).
    * - An empty array explicitly signals that the geometry types are not known.
-   * - The geometry types in the list must be unique (e.g. `["Point", "Point"]`
+   * - The geometry types in the list must be unique (e.g. `[0001, 0001]`
    *   is not valid).
    *
-   * Please refer to link below for more detail:
-   * https://github.com/opengeospatial/geoparquet/blob/v1.0.0/format-specs/geoparquet.md?plain=1#L91
+   * Please refer to links below for more detail:
+   * [1] https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary
+   * [2] https://github.com/opengeospatial/geoparquet/blob/v1.0.0/format-specs/geoparquet.md?plain=1#L91
    */
-  3: optional list<string> geometry_types;
+  3: optional list<i32> geometry_types;
 }
 
 /**
@@ -473,14 +483,14 @@ struct GeometryType {
    */
   1: required GeometryEncoding encoding;
   /**
+   * Edges of polygon.
+   */
+  2: required Edges edges;
+  /**
    * Coordinate Reference System, i.e. mapping of how coordinates refer to
    * precise locations on earth, e.g. OGC:CRS84
    */
-  2: optional string crs;
-  /**
-   * Edges of polygon.
-   */
-  3: optional Edges edges;
+  3: optional string crs;
   /**
    * Additional informative metadata.
    * It can be used by GeoParquet to offload some of the column metadata.

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -240,7 +240,7 @@ struct SizeStatistics {
 /**
  * Interpretation for edges of GEOMETRY logical type, i.e. whether the edge
  * between points represent a straight cartesian line or the shortest line on
- * the sphere. Please note that it only applies to polygons.
+ * the sphere. It applies to all non-point geometry objects.
  */
 enum Edges {
   PLANAR = 0;
@@ -260,7 +260,7 @@ struct Covering {
    */
   1: required string kind;
   /**
-   * A payload specific to kind:
+   * A payload specific to kind. Below are the supported values:
    * - WKB: well-known binary of a POLYGON or MULTI-POLYGON that completely
    *   covers the contents. This will be interpreted according to the same CRS
    *   and edges defined by the logical type.
@@ -470,22 +470,20 @@ enum GeometryEncoding {
   /**
    * Allowed for physical type: BYTE_ARRAY.
    *
-   * Well-known binary (WKB) representations of geometries. It supports 2D or
-   * 3D geometries of the standard geometry types (Point, LineString, Polygon,
-   * MultiPoint, MultiLineString, MultiPolygon, and GeometryCollection). This
-   * is the preferred option for maximum portability.
+   * Well-known binary (WKB) representations of geometries.
    *
-   * This encoding enables GeometryStatistics to be set in the column chunk
-   * and page index.
+   * To be clear, we follow the same rule of WKB and coordinate axis order from
+   * GeoParquet [1][2]. It is the ISO WKB supporting XY, XYZ, XYM, XYZM and the
+   * standard geometry types (Point, LineString, Polygon, MultiPoint,
+   * MultiLineString, MultiPolygon, and GeometryCollection).
    *
-   * Please note that we follow the same rule of WKB and coordinate axis order
-   * of GeoParquet, see detail below:
+   * This is the preferred encoding for maximum portability. It also supports
+   * GeometryStatistics to be set in the column chunk and page index.
+   *
    * [1] https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L92
    * [2] https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L155
    */
   WKB = 0;
-
-  // TODO: add native encoding from GeoParquet/GeoArrow
 }
 
 /**
@@ -493,12 +491,13 @@ enum GeometryEncoding {
  */
 struct GeometryType {
   /**
-   * Physical type and encoding for the geometry type. Please refer to the
-   * definition of GeometryEncoding for more detail.
+   * Physical type and encoding for the geometry type.
+   * Please refer to the definition of GeometryEncoding for more detail.
    */
   1: required GeometryEncoding encoding;
   /**
-   * Edges of polygon.
+   * Edges of geometry type.
+   * Please refer to the definition of Edges for more detail.
    */
   2: required Edges edges;
   /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -240,7 +240,7 @@ struct SizeStatistics {
 /**
  * Interpretation for edges of GEOMETRY logical type, i.e. whether the edge
  * between points represent a straight cartesian line or the shortest line on
- * the sphere.
+ * the sphere. Please note that it only applies to polygons.
  */
 enum Edges {
   PLANAR = 0;
@@ -248,20 +248,17 @@ enum Edges {
 }
 
 /**
- * A custom WKB-encoded geometry data to be used in geometry statistics.
- * The geometry may be a polygon to encode an s2 or h3 covering to provide
- * vendor-agnostic coverings, or an evelope of geometries when a bounding
- * box cannot be built (e.g. a geometry has spherical edges, or if an edge
- * of geographic coordinates crosses the antimeridian).
+ * A custom WKB-encoded polygon or multi-polygon to represent a covering of
+ * geometries. For example, it may be a bounding box, or an evelope of geometries
+ * when a bounding box cannot be built (e.g. a geometry has spherical edges, or if
+ * an edge of geographic coordinates crosses the antimeridian). In addition, it can
+ * also be used to provide vendor-agnostic coverings like S2 or H3 grids.
  */
-struct Geometry {
+struct Covering {
   /** Bytes of a WKB-encoded geometry */
   1: required binary geometry;
-  /**
-   * Edges of the geometry if it is a polygon. It may be different to the
-   * edges attribute from the GEOMETRY logical type.
-   */
-  2: optional Edges edges;
+  /** Edges of the geometry, which is independent of edges from the logical type */
+  2: required Edges edges;
 }
 
 /**
@@ -279,15 +276,13 @@ struct BoundingBox {
   8: optional double mmax;
 }
 
-struct Covering {
-  optional BoundingBox bbox    // A bounding box of geometries if it can be built.
-  optional Geometry covering   // A covering polygon of geometries if bbox is unavailable.
-}
-
 /** Statistics specific to GEOMETRY logical type */
 struct GeometryStatistics {
-  /** Covering of geometries */
-  1: optional Covering covering;
+  /** A bounding box of geometries */
+  1: optional BoundingBox bbox;
+
+  /** A covering polygon of geometries */
+  2: optional Covering covering;
 
   /**
    * The geometry types of all geometries, or an empty array if they are not
@@ -306,7 +301,7 @@ struct GeometryStatistics {
    * Please refer to link below for more detail:
    * https://github.com/opengeospatial/geoparquet/blob/v1.0.0/format-specs/geoparquet.md?plain=1#L91
    */
-  2: optional list<string> geometry_types;
+  3: optional list<string> geometry_types;
 }
 
 /**
@@ -449,7 +444,7 @@ struct BsonType {
 }
 
 /**
- * Phyiscal type and encoding for the geometry type.
+ * Physical type and encoding for the geometry type.
  */
 enum GeometryEncoding {
   /**
@@ -490,7 +485,7 @@ struct GeometryType {
    * Additional informative metadata.
    * It can be used by GeoParquet to offload some of the column metadata.
    */
-  4: optional string metadata;
+  4: optional binary metadata;
 }
 
 /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -491,23 +491,23 @@ struct GeometryType {
   1: required GeometryEncoding encoding;
   /**
    * Interpretation for edges of elements of a GEOMETRY logical type, i.e. whether
-   * the interpolation between points along an edge represents a straight cartesian
-   * line or the shortest line on the sphere.
+   * the interpolation between points along an edge represents a straight line in
+   * Euclidean space or the shortest line on the sphere.
    * Please refer to the definition of Edges for more detail.
    */
   2: required Edges edges;
   /**
-   * CRS (coordinate reference system) is a mapping of how coordinates refer to
-   * precise locations on earth. A crs is specified by a string, which is a Parquet
-   * file metadata field whose value is the crs representation. An additional field
-   * with the suffix '.type' describes the encoding of this CRS representation.
+   * CRS (coordinate reference system) is a description of how coordinates refer to
+   * precise locations on earth. A CRS is specified by a string, which is a Parquet
+   * file metadata field whose value is the CRS representation. An additional field
+   * with the suffix '.encoding' describes the encoding of this CRS representation.
    *
    * For example, if a geometry column (e.g., 'geom1') uses the CRS 'OGC:CRS84', the
-   * writer may create 2 file metadata fields: 'geom1_crs' and 'geom1_crs.type', and
-   * set the 'crs' field to 'geom1_crs'. The 'geom1_crs' field will contain the
+   * writer may create 2 file metadata fields: 'geom1_crs' and 'geom1_crs.encoding',
+   * and set the 'crs' field to 'geom1_crs'. The 'geom1_crs' field may contain the
    * PROJJSON representation of OGC:CRS84
    * (https://github.com/opengeospatial/geoparquet/blob/main/format-specs/geoparquet.md#ogccrs84-details),
-   * and the 'geom1_crs.type' field will contain the string 'PROJJSON'.
+   * and the 'geom1_crs.encoding' field would contain the string 'PROJJSON'.
    *
    * Multiple geometry columns can refer to the same CRS metadata field
    * (e.g., 'geom1_crs') if they share the same CRS.

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -238,6 +238,36 @@ struct SizeStatistics {
 }
 
 /**
+ * Physical type and encoding for the geometry type.
+ */
+enum GeometryEncoding {
+  /**
+   * Allowed for physical type: BYTE_ARRAY.
+   *
+   * Well-known binary (WKB) representations of geometries.
+   *
+   * To be clear, we follow the same rule of WKB and coordinate axis order from
+   * GeoParquet [1][2]. Geometries SHOULD be encoded as ISO WKB [3][4]
+   * supporting XY, XYZ, XYM, XYZM and the standard geometry types
+   * Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon,
+   * and GeometryCollection). Coordinate order is always (x, y) where x is
+   * easting or longitude and y is northing or latitude. This ordering explicitly
+   * overrides the axis order as specified in the CRS following the GeoPackage
+   * specification [5].
+   *
+   * This is the preferred encoding for maximum portability. It also supports
+   * GeometryStatistics to be set in the column chunk and page index.
+   *
+   * [1] https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L92
+   * [2] https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L155
+   * [3] https://portal.ogc.org/files/?artifact_id=18241
+   * [4] https://www.iso.org/standard/60343.html
+   * [5] https://www.geopackage.org/spec130/#gpb_spec
+   */
+  WKB = 0;
+}
+
+/**
  * Interpretation for edges of elements of a GEOMETRY logical type. In other
  * words, whether a point between two vertices should be interpolated in
  * its XY dimensions as if it were a Cartesian line connecting the two
@@ -249,7 +279,7 @@ struct SizeStatistics {
  * Because most systems currently assume planar edges and do not support
  * spherical edges, planar should be used as the default value.
  */
-enum Edges {
+enum EdgeInterpolation {
   PLANAR = 0;
   SPHERICAL = 1;
 }
@@ -476,36 +506,6 @@ struct BsonType {
 }
 
 /**
- * Physical type and encoding for the geometry type.
- */
-enum GeometryEncoding {
-  /**
-   * Allowed for physical type: BYTE_ARRAY.
-   *
-   * Well-known binary (WKB) representations of geometries.
-   *
-   * To be clear, we follow the same rule of WKB and coordinate axis order from
-   * GeoParquet [1][2]. Geometries SHOULD be encoded as ISO WKB [3][4]
-   * supporting XY, XYZ, XYM, XYZM and the standard geometry types 
-   * Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon,
-   * and GeometryCollection). Coordinate order is always (x, y) where x is
-   * easting or longitude and y is northing or latitude. This ordering explicitly
-   * overrides the axis order as specified in the CRS following the GeoPackage
-   * specification [5].
-   *
-   * This is the preferred encoding for maximum portability. It also supports
-   * GeometryStatistics to be set in the column chunk and page index.
-   *
-   * [1] https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L92
-   * [2] https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L155
-   * [3] https://portal.ogc.org/files/?artifact_id=18241
-   * [4] https://www.iso.org/standard/60343.html
-   * [5] https://www.geopackage.org/spec130/#gpb_spec
-   */
-  WKB = 0;
-}
-
-/**
  * Geometry logical type annotation (added in 2.11.0)
  */
 struct GeometryType {
@@ -515,10 +515,12 @@ struct GeometryType {
    */
   1: required GeometryEncoding encoding;
   /**
-   * Edges of geometry type.
+   * Interpretation for edges of elements of a GEOMETRY logical type, i.e. whether
+   * the interpolation between points along an edge represents a straight cartesian
+   * line or the shortest line on the sphere.
    * Please refer to the definition of Edges for more detail.
    */
-  2: required Edges edges;
+  2: required EdgeInterpolation edges;
   /**
    * Coordinate Reference System, i.e. mapping of how coordinates refer to
    * precise locations on earth. Writers are not required to set this field.
@@ -567,11 +569,12 @@ struct GeometryType {
    */
   4: optional string crs_encoding;
   /**
-   * Additional informative metadata.
-   * GeoParquet could offload its column metadata in a JSON-encoded UTF-8 string:
-   * https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L46
+   * Additional informative metadata as a list of key-value pair of UTF-8 string.
+   * It is not strictly required by the low-level Parquet implementation for
+   * features like statistics or filter pushdown. Using a list of key-value pair
+   * provides maximum flexibility for adding future informative metadata.
    */
-  5: optional string metadata;
+  5: optional list<KeyValue> key_value_metadata;
 }
 
 /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -501,6 +501,9 @@ struct GeometryType {
    * precise locations on earth. A CRS is specified by a string, which is a Parquet
    * file metadata field whose value is the CRS representation. An additional field
    * with the suffix '.encoding' describes the encoding of this CRS representation.
+   * An optional third field with the suffix '.permutation' describes the change in
+   * axis order and direction between the CRS definition and the coordinates stored
+   * in the geometries.
    *
    * For example, if a geometry column (e.g., 'geom1') uses the CRS 'OGC:CRS84', the
    * writer may create 2 file metadata fields: 'geom1_crs' and 'geom1_crs.encoding',
@@ -508,6 +511,23 @@ struct GeometryType {
    * PROJJSON representation of OGC:CRS84
    * (https://github.com/opengeospatial/geoparquet/blob/main/format-specs/geoparquet.md#ogccrs84-details),
    * and the 'geom1_crs.encoding' field would contain the string 'PROJJSON'.
+   *
+   * Geographic CRSs often use (latitude, longitude) axis order, while coordinates
+   * in WKB are (east, north). When the CRS and the geometries use different axis
+   * order or orientation, the change shall be described in a '.permutation' field.
+   * This field contains a sequence of n distinct integers whose absolute values
+   * are between 1 and n inclusive, where n is the number of dimensions. For each
+   * CRS axis at index 'i', the `abs(permutation[i])' value is the one-based
+   * coordinate index in the geometry: 1 for x, 2 for y, 3 for z, and 4 for m.
+   * A negative index specifies that the sign of coordinate values shall be reversed.
+   *
+   * Example 1: if the CRS declares (latitude, longitude, height) axes but the
+   * geometry stores (longitude, latitude, height) coordinates, then the
+   * permutation shall be (2, 1, 3).
+   *
+   * Example 2: for the same case as example 1 but where the longitude axis of
+   * the CRS is oriented toward West instead of East (as in some North American
+   * CRSs), then the permutation shall be (2, -1, 3).
    *
    * Multiple geometry columns can refer to the same CRS metadata field
    * (e.g., 'geom1_crs') if they share the same CRS.

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -238,35 +238,96 @@ struct SizeStatistics {
 }
 
 /**
+ * Interpretation for edges of GEOMETRY logical type, i.e. whether the edge
+ * between points represent a straight cartesian line or the shortest line on
+ * the sphere.
+ */
+enum Edges {
+  PLANAR = 0;
+  SPHERICAL = 1;
+}
+
+/**
+ * A custom WKB-encoded geometry data to be used in geometry statistics.
+ * The geometry may be a polygon to encode an s2 or h3 covering to provide
+ * vendor-agnostic coverings, or an evelope of geometries when a bounding
+ * box cannot be built (e.g. a geometry has spherical edges, or if an edge
+ * of geographic coordinates crosses the antimeridian).
+ */
+struct Geometry {
+  /** Bytes of a WKB-encoded geometry */
+  1: required binary geometry;
+  /**
+   * Edges of the geometry if it is a polygon. It may be different to the
+   * edges attribute from the GEOMETRY logical type.
+   */
+  2: optional Edges edges;
+}
+
+/**
  * Bounding box of geometries in the representation of min/max value pair of
  * coordinates from each axis. Values of Z and M are omitted for 2D geometries.
  */
 struct BoundingBox {
-  1: optional double x_min;
-  2: optional double x_max;
-  3: optional double y_min;
-  4: optional double y_max;
-  5: optional double z_min;
-  6: optional double z_max;
-  7: optional double m_min;
-  8: optional double m_max;
+  1: required double xmin;
+  2: required double xmax;
+  3: required double ymin;
+  4: required double ymax;
+  5: optional double zmin;
+  6: optional double zmax;
+  7: optional double mmin;
+  8: optional double mmax;
+}
+
+union Envelope {
+  1:  BoundingBox bbox    // A bounding box of geometries if it can be built.
+  2:  Geometry covering   // A covering polygon of geometries if bbox is unavailable.
+}
+
+/** S2 spatial index: http://s2geometry.io/ */
+struct S2Index {
+  /** Level of S2 cell ids. valid range is [0, 30] */
+  1: required i32 level;
+  /** Covering of geometries as a list of Google S2 cell ids */
+  2: required list<i64> cell_ids;
+}
+
+/** H3 spatial index: https://h3geo.org */
+struct H3Index {
+  /** Precision of H3 cell ids. valid range is [0, 15] */
+  1: required i32 precision;
+  /** Covering of geometries as a list of Uber H3 indices */
+  2: required list<i64> cell_ids;
 }
 
 /** Statistics specific to GEOMETRY logical type */
 struct GeometryStatistics {
-  /** Bounding box of geometries */
-  1: optional BoundingBox bbox;
-  /** Covering of geometries as a list of Google S2 cell ids */
-  2: list<i64> s2_cell_ids;
-  /** Covering of geometries as a list of Uber H3 indices */
-  3: list<i64> h3_indices;
+  /** Envelope of geometries */
+  1: optional Envelope envelope;
+
   /**
    * The geometry types of all geometries, or an empty array if they are not
    * known. It follows the same rule of `geometry_types` column metadata of
    * GeoParquet. Accepted geometry types are: "Point", "LineString", "Polygon",
    * "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection".
+   *
+   * In addition, the following rules are used:
+   * - In case of 3D geometries, a `" Z"` suffix gets added (e.g. `["Point Z"]`).
+   * - A list of multiple values indicates that multiple geometry types are
+   *   present (e.g. `["Polygon", "MultiPolygon"]`).
+   * - An empty array explicitly signals that the geometry types are not known.
+   * - The geometry types in the list must be unique (e.g. `["Point", "Point"]`
+   *   is not valid).
+   *
+   * Please refer to link below for more detail:
+   * https://github.com/opengeospatial/geoparquet/blob/v1.0.0/format-specs/geoparquet.md?plain=1#L91
    */
-  4: list<string> geometry_types;
+  2: optional list<string> geometry_types;
+
+  // S2 and H3 are controversial from the discussion. Now they are commented
+  // out to show a possible approach for future extension.
+  // 3: optional S2Index s2;
+  // 4: optional H3Index h3;
 }
 
 /**
@@ -433,9 +494,6 @@ enum GeometryEncoding {
    * results in useful column statistics when row groups and/or files contain
    * related features.
    *
-   * WARNING: GeometryStatistics cannot be enabled for these encodings because
-   * only leaf columns can have column statistics and page index.
-   *
    * The actual coordinates of the geometries MUST be stored as native numbers,
    * i.e. using the DOUBLE type in a (repeated) group of fields (exact
    * repetition depending on the geometry type).
@@ -449,13 +507,20 @@ enum GeometryEncoding {
    *
    * For more detail, please refer to link below:
    * https://github.com/opengeospatial/geoparquet/blob/main/format-specs/geoparquet.md#encoding
+   *
+   * WARNING: GeometryStatistics cannot be enabled for these encodings because
+   * only leaf columns can have column statistics and page index. In this case,
+   * the statistics for the leaf columns contain equivalent information to the
+   * bounding box.
    */
-  POINT = 1;
-  LINESTRING = 2;
-  POLYGON = 3;
-  MULTIPOINT = 4;
-  MULTILINESTRING = 5;
-  MULTIPOLYGON = 6;
+  // Native encodings are controversial from the discussion. Now they are commented
+  // out to show a possible approach for future extension.
+  // POINT = 1;
+  // LINESTRING = 2;
+  // POLYGON = 3;
+  // MULTIPOINT = 4;
+  // MULTILINESTRING = 5;
+  // MULTIPOLYGON = 6;
 }
 
 /**
@@ -468,12 +533,19 @@ struct GeometryType {
    */
   1: required GeometryEncoding encoding;
   /**
+   * Coordinate Reference System, i.e. mapping of how coordinates refer to
+   * precise locations on earth, e.g. OGC:CRS84
+   */
+  2: optional string crs;
+  /**
+   * Edges of polygon.
+   */
+  3: optional Edges edges;
+  /**
    * Additional informative metadata.
    * It can be used by GeoParquet to offload some of the column metadata.
    */
-  2: optional string metadata;
-  /** File-level statistics for geometries */
-  3: optional GeometryStatistics statistics;
+  4: optional string metadata;
 }
 
 /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -490,6 +490,9 @@ enum GeometryEncoding {
    *
    * [1] https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L92
    * [2] https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L155
+   * [3] https://portal.ogc.org/files/?artifact_id=18241
+   * [4] https://www.iso.org/standard/60343.html
+   * [5] https://www.geopackage.org/spec130/#gpb_spec
    */
   WKB = 0;
 }

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -279,31 +279,15 @@ struct BoundingBox {
   8: optional double mmax;
 }
 
-union Envelope {
-  1:  BoundingBox bbox    // A bounding box of geometries if it can be built.
-  2:  Geometry covering   // A covering polygon of geometries if bbox is unavailable.
-}
-
-/** S2 spatial index: http://s2geometry.io/ */
-struct S2Index {
-  /** Level of S2 cell ids. valid range is [0, 30] */
-  1: required i32 level;
-  /** Covering of geometries as a list of Google S2 cell ids */
-  2: required list<i64> cell_ids;
-}
-
-/** H3 spatial index: https://h3geo.org */
-struct H3Index {
-  /** Precision of H3 cell ids. valid range is [0, 15] */
-  1: required i32 precision;
-  /** Covering of geometries as a list of Uber H3 indices */
-  2: required list<i64> cell_ids;
+struct Covering {
+  optional BoundingBox bbox    // A bounding box of geometries if it can be built.
+  optional Geometry covering   // A covering polygon of geometries if bbox is unavailable.
 }
 
 /** Statistics specific to GEOMETRY logical type */
 struct GeometryStatistics {
-  /** Envelope of geometries */
-  1: optional Envelope envelope;
+  /** Covering of geometries */
+  1: optional Covering covering;
 
   /**
    * The geometry types of all geometries, or an empty array if they are not
@@ -323,11 +307,6 @@ struct GeometryStatistics {
    * https://github.com/opengeospatial/geoparquet/blob/v1.0.0/format-specs/geoparquet.md?plain=1#L91
    */
   2: optional list<string> geometry_types;
-
-  // S2 and H3 are controversial from the discussion. Now they are commented
-  // out to show a possible approach for future extension.
-  // 3: optional S2Index s2;
-  // 4: optional H3Index h3;
 }
 
 /**
@@ -486,41 +465,7 @@ enum GeometryEncoding {
    */
   WKB = 0;
 
-  /**
-   * Encodings from POINT to MULTIPOLYGON below are specialized for single
-   * geometry type and inspired by GeoArrow (https://geoarrow.org/format.html)
-   * native encodings. It uses the separated (struct) representation of
-   * coordinates for single-geometry type encodings because this encoding
-   * results in useful column statistics when row groups and/or files contain
-   * related features.
-   *
-   * The actual coordinates of the geometries MUST be stored as native numbers,
-   * i.e. using the DOUBLE type in a (repeated) group of fields (exact
-   * repetition depending on the geometry type).
-   *
-   * For the POINT encoding, this results in a struct of two fields for x and y
-   * coordinates (in case of 2D geometries):
-   * optional group geometry {
-   *   required double x;
-   *   required double y;
-   * }
-   *
-   * For more detail, please refer to link below:
-   * https://github.com/opengeospatial/geoparquet/blob/main/format-specs/geoparquet.md#encoding
-   *
-   * WARNING: GeometryStatistics cannot be enabled for these encodings because
-   * only leaf columns can have column statistics and page index. In this case,
-   * the statistics for the leaf columns contain equivalent information to the
-   * bounding box.
-   */
-  // Native encodings are controversial from the discussion. Now they are commented
-  // out to show a possible approach for future extension.
-  // POINT = 1;
-  // LINESTRING = 2;
-  // POLYGON = 3;
-  // MULTIPOINT = 4;
-  // MULTILINESTRING = 5;
-  // MULTIPOLYGON = 6;
+  // TODO: add native encoding from GeoParquet/GeoArrow
 }
 
 /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -448,7 +448,7 @@ struct BsonType {
  */
 enum GeometryEncoding {
   /**
-   * Allowed for phyiscal type: BYTE_ARRAY.
+   * Allowed for physical type: BYTE_ARRAY.
    *
    * Well-known binary (WKB) representations of geometries. It supports 2D or
    * 3D geometries of the standard geometry types (Point, LineString, Polygon,
@@ -468,7 +468,7 @@ enum GeometryEncoding {
  */
 struct GeometryType {
   /**
-   * Phyiscal type and encoding for the geometry type. Please refer to the
+   * Physical type and encoding for the geometry type. Please refer to the
    * definition of GeometryEncoding for more detail.
    */
   1: required GeometryEncoding encoding;

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -477,9 +477,13 @@ enum GeometryEncoding {
    * Well-known binary (WKB) representations of geometries.
    *
    * To be clear, we follow the same rule of WKB and coordinate axis order from
-   * GeoParquet [1][2]. It is the ISO WKB supporting XY, XYZ, XYM, XYZM and the
-   * standard geometry types (Point, LineString, Polygon, MultiPoint,
-   * MultiLineString, MultiPolygon, and GeometryCollection).
+   * GeoParquet [1][2]. Geometries SHOULD be encoded as ISO WKB [3][4]
+   * supporting XY, XYZ, XYM, XYZM and the standard geometry types 
+   * Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon,
+   * and GeometryCollection). Coordinate order is always (x, y) where x is
+   * easting or longitude and y is northing or latitude. This ordering explicitly
+   * overrides the axis order as specified in the CRS following the GeoPackage
+   * specification [5].
    *
    * This is the preferred encoding for maximum portability. It also supports
    * GeometryStatistics to be set in the column chunk and page index.


### PR DESCRIPTION
The first commit renames `.type` as `.encoding`. The "Type" term is incorrect in this context. A CRS type would be, for example, "geographic" versus "projected". The CRS encoding is unrelated to the CRS type.

The second commit adds a `permutation` attribute for making explicit that, for example, WKB uses (longitude, latitude) despite a CRS declaring (latitude, longitude). Relying on WKB specification or GeoParquet examples are unsatisfying. They are deprecated practices, still in use for legacy reasons, but OGC requests us to not do that anymore in new standards.

See [OGC directive 14 — axis order](https://portal.ogc.org/public_ogc/directives/directives.php#14) (approved in June 2017). WKB is applying the case 4:

> **Case 4:** (…snip…) The payloads would then be encoded using the axis order as specified in the spec document and not in the CRS metadata. **The OGC does not recommend implementing this use case.**

Latter, the OGC directive said:

> A number of existing OGC standards may not fully comply with the requirements as stated above. For those cases, the OGC SHALL, as far as feasible, make future versions of such OGC standard compliant with the requirements as specified in Use Cases 1, 2, and 3 above.

This pull request is applying case 2:

> **Case 2:** Payload encoding explicitly overrides the Axis Order as specified in the CRS metadata: In this case the payload explicitly encodes additional metadata in order to determine axis order.

Example: ISO 19107:2019 defines a "permutation" field for this purpose (above OGC directive cite a "reordering" attribute, but it was before the final version of the ISO standard). This pull request is consistent with ISO 19107 §6.2.8.6 and §6.2.2.0.2.

Another source of inspiration is GDAL [GetDataAxisToSRSAxisMapping()](https://gdal.org/en/latest/api/ogrspatialref.html#classOGRSpatialReference_1a50a4542a228db455df2126e98a971d5d) function, which is exactly the same thing as this pull request with only a different name. This pull request took the negative sign convention from that GDAL function.